### PR TITLE
Modify the size of labels to fix warnings on GPU

### DIFF
--- a/cpp/dcgan/dcgan.cpp
+++ b/cpp/dcgan/dcgan.cpp
@@ -141,7 +141,7 @@ int main(int argc, const char* argv[]) {
       discriminator->zero_grad();
       torch::Tensor real_images = batch.data.to(device);
       torch::Tensor real_labels =
-          torch::empty(batch.data.size(0), device).uniform_(0.8, 1.0);
+          torch::empty({batch.data.size(0),1,1,1}, device).uniform_(0.8, 1.0);
       torch::Tensor real_output = discriminator->forward(real_images);
       torch::Tensor d_loss_real =
           torch::binary_cross_entropy(real_output, real_labels);
@@ -151,7 +151,7 @@ int main(int argc, const char* argv[]) {
       torch::Tensor noise =
           torch::randn({batch.data.size(0), kNoiseSize, 1, 1}, device);
       torch::Tensor fake_images = generator->forward(noise);
-      torch::Tensor fake_labels = torch::zeros(batch.data.size(0), device);
+      torch::Tensor fake_labels = torch::zeros({batch.data.size(0),1,1,1}, device);
       torch::Tensor fake_output = discriminator->forward(fake_images.detach());
       torch::Tensor d_loss_fake =
           torch::binary_cross_entropy(fake_output, fake_labels);


### PR DESCRIPTION
When I was training the model on CPU, everything's OK. When I tried to train on GPU, it incessantly print the following warning message.
`[W ..\..\aten\src\ATen\native\Resize.cpp:19] Warning: An output with one or more elements was resized since it had shape [64, 1, 1, 1], which does not match the required output shape [64, 1, 1, 64].This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0). (function resize_output)`
The warning happens each time backward() function is called. It seems that tensors of size {64} will not be compatible in calculation with tensors of size {64,1,1,1} in the future PyTorch release. After I modified the size of fake_labels and real_labels to {64,1,1,1}, the warning messages disappeared.